### PR TITLE
17 post article

### DIFF
--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,19 +1,21 @@
 import { getRequest } from "../utils/api";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
 import ArticleCard from "./ArticleCard";
 import Loading from "./Loading";
 import ArticlesSideBar from "./ArticlesSideBar";
 import ErrorComponent from "./ErrorComponent";
 import ArticlesListOptions from "./ArticlesListOptions";
+import { TopicsContext } from "../contexts/TopicsContext";
+
 const Articles = ({
   listArticles,
   setlistArticles,
   isLoading,
   setIsLoading,
-  topics,
-  setTopics,
 }) => {
+  const { topics, awaitingTopics } = useContext(TopicsContext);
+
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentTopic, setCurrentTopic] = useState(searchParams.get("topic"));
   const [currentTopicDescription, setCurrentTopicDescription] = useState("");
@@ -38,19 +40,17 @@ const Articles = ({
   }, [sortBy, order]);
 
   useEffect(() => {
-    getRequest("/api/topics").then(({ topics }) => {
-      setTopics(topics);
-
+    if (!currentTopic & !awaitingTopics) {
       const currentTopicApi = topics.filter((apiTopic) => {
         return apiTopic.slug === currentTopic;
       });
       setCurrentTopicDescription(currentTopicApi[0].description);
-    });
+    }
   }, [currentTopic]);
 
   return (
     <div className="flex">
-      <ArticlesSideBar topics={topics} currentTopic={currentTopic} />
+      <ArticlesSideBar currentTopic={currentTopic} />
       <div>
         <div className="m-10">
           <div>

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -40,7 +40,7 @@ const Articles = ({
   }, [sortBy, order]);
 
   useEffect(() => {
-    if (!currentTopic & !awaitingTopics) {
+    if (currentTopic && !awaitingTopics) {
       const currentTopicApi = topics.filter((apiTopic) => {
         return apiTopic.slug === currentTopic;
       });

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -11,11 +11,12 @@ const Articles = ({
   setlistArticles,
   isLoading,
   setIsLoading,
+  topics,
+  setTopics,
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentTopic, setCurrentTopic] = useState(searchParams.get("topic"));
   const [currentTopicDescription, setCurrentTopicDescription] = useState("");
-  const [topics, setTopics] = useState([]);
   const [sortBy, setSortBy] = useState(searchParams.get("sort_by"));
   const [order, setOrder] = useState(searchParams.get("order"));
   const [error, setError] = useState(null);

--- a/src/components/ArticlesContainer.jsx
+++ b/src/components/ArticlesContainer.jsx
@@ -10,6 +10,7 @@ import ErrorPage from "./ErrorPage";
 
 const ArticlesContainer = () => {
   const [listArticles, setlistArticles] = useState([]);
+  const [topics, setTopics] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [article, setArticle] = useState({});
   return (
@@ -33,6 +34,8 @@ const ArticlesContainer = () => {
             setlistArticles={setlistArticles}
             isLoading={isLoading}
             setIsLoading={setIsLoading}
+            topics={topics}
+            setTopics={setTopics}
           />
         }
       />

--- a/src/components/ArticlesContainer.jsx
+++ b/src/components/ArticlesContainer.jsx
@@ -10,7 +10,6 @@ import ErrorPage from "./ErrorPage";
 
 const ArticlesContainer = () => {
   const [listArticles, setlistArticles] = useState([]);
-  const [topics, setTopics] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [article, setArticle] = useState({});
   return (
@@ -34,8 +33,6 @@ const ArticlesContainer = () => {
             setlistArticles={setlistArticles}
             isLoading={isLoading}
             setIsLoading={setIsLoading}
-            topics={topics}
-            setTopics={setTopics}
           />
         }
       />

--- a/src/components/ArticlesSideBar.jsx
+++ b/src/components/ArticlesSideBar.jsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import MenuIcon from "@mui/icons-material/Menu";
 import CloseIcon from "@mui/icons-material/Close";
+import { TopicsContext } from "../contexts/TopicsContext";
+import Loading from "./Loading";
 
-export default function ArticleSidebar({ topics, currentTopic }) {
+export default function ArticleSidebar({ currentTopic }) {
+  const { topics, awaitingTopics } = useContext(TopicsContext);
+
   const [expanded, setExpanded] = useState(false);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const [menuStyle, setMenuStyle] = useState("");
@@ -40,22 +44,27 @@ export default function ArticleSidebar({ topics, currentTopic }) {
               <CloseIcon onClick={() => setExpanded(false)} />
             ) : null}
             <h4 className="mb-4 font-bold mt-4">Topics</h4>
-            <ul>
-              {topics.map((topic) => {
-                const topicSelectedClass =
-                  currentTopic === topic.slug ? "font-bold" : "";
-                return (
-                  <Link
-                    to={`/articles?topic=${topic.slug}`}
-                    reloadDocument="true"
-                  >
-                    <li className={topicSelectedClass} key={topic.slug}>
-                      {topic.slug}
-                    </li>
-                  </Link>
-                );
-              })}
-            </ul>
+            {awaitingTopics ? (
+              <Loading />
+            ) : (
+              <ul>
+                {topics.map((topic) => {
+                  const topicSelectedClass =
+                    currentTopic === topic.slug ? "font-bold" : "";
+                  return (
+                    <Link
+                      to={`/articles?topic=${topic.slug}`}
+                      reloadDocument="true"
+                      key={topic.slug}
+                    >
+                      <li className={topicSelectedClass} key={topic.slug}>
+                        {topic.slug}
+                      </li>
+                    </Link>
+                  );
+                })}
+              </ul>
+            )}
           </section>
         </div>
       ) : (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,8 +13,8 @@ const Header = () => {
           <h1 className=" text-[65px] font-mono text-red-600">nc news</h1>
         </div>
       </Link>
-      <div className="grid grid-cols-5 items-center">
-        <hr className=" border-grey-400 border col-span-4 mr-3"></hr>
+      <div className="flex items-center">
+        <hr className=" border-grey-400 border col-span-4 mr-3 grow"></hr>
         <NavMenu />
       </div>
     </div>

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -1,4 +1,4 @@
-const NavButton = ({ buttonText, handleClick }) => {
+const NavButton = ({ buttonText, handleClick, icon }) => {
   return (
     <div>
       <button
@@ -7,6 +7,7 @@ const NavButton = ({ buttonText, handleClick }) => {
         onClick={handleClick}
         className=" p-2 bg-red-50 rounded-full text-nowrap"
       >
+        {icon ? icon : null}
         {buttonText}
       </button>
     </div>

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -5,7 +5,7 @@ const NavButton = ({ buttonText, handleClick }) => {
         data-cy="button"
         type="button"
         onClick={handleClick}
-        className=" p-2 bg-red-50 rounded-full"
+        className=" p-2 bg-red-50 rounded-full text-nowrap"
       >
         {buttonText}
       </button>

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -1,6 +1,5 @@
 const NavButton = ({ buttonText, handleClick, icon }) => {
   return (
-    <div>
       <button
         data-cy="button"
         type="button"
@@ -10,7 +9,6 @@ const NavButton = ({ buttonText, handleClick, icon }) => {
         {icon ? icon : null}
         {buttonText}
       </button>
-    </div>
   );
 };
 

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -1,14 +1,14 @@
 const NavButton = ({ buttonText, handleClick, icon }) => {
   return (
-      <button
-        data-cy="button"
-        type="button"
-        onClick={handleClick}
-        className=" p-2 bg-red-50 rounded-full text-nowrap"
-      >
-        {icon ? icon : null}
-        {buttonText}
-      </button>
+    <button
+      data-cy="button"
+      type="button"
+      onClick={handleClick}
+      className=" p-2 bg-red-50 rounded-full text-nowrap"
+    >
+      {icon ? icon : null}
+      {buttonText}
+    </button>
   );
 };
 

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -8,9 +8,14 @@ const NavMenu = () => {
   return (
     <div>
       {user ? (
-        <Link to="/account">
-          <NavButton buttonText={"My Account"} />
-        </Link>
+        <div className="flex">
+          <Link to="/articles/post">
+            <NavButton buttonText={"Post Article"} />
+          </Link>
+          <Link to="/account">
+            <NavButton buttonText={"My Account"} />
+          </Link>
+        </div>
       ) : (
         <Link to="login">
           <NavButton buttonText={"Log In"} />

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -1,6 +1,9 @@
 import { Link } from "react-router-dom";
 import { UserContext } from "../contexts/UserContext";
 import { useContext } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import FaceIcon from "@mui/icons-material/Face";
+import LoginIcon from "@mui/icons-material/Login";
 import NavButton from "./NavButton";
 const NavMenu = () => {
   const { user } = useContext(UserContext);
@@ -10,15 +13,15 @@ const NavMenu = () => {
       {user ? (
         <div className="flex">
           <Link to="/articles/post">
-            <NavButton buttonText={"Post Article"} />
+            <NavButton buttonText={"Post Article"} icon={<AddIcon />} />
           </Link>
           <Link to="/account">
-            <NavButton buttonText={"My Account"} />
+            <NavButton buttonText={"My Account"} icon={<FaceIcon />} />
           </Link>
         </div>
       ) : (
         <Link to="login">
-          <NavButton buttonText={"Log In"} />
+          <NavButton buttonText={"Log In"} icon={<LoginIcon />} />
         </Link>
       )}
     </div>

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -4,6 +4,7 @@ import Select from "@mui/material/Select";
 import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
 import PublishIcon from "@mui/icons-material/Publish";
+import InputLabel from "@mui/material/InputLabel";
 import { useState, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { TopicsContext } from "../contexts/TopicsContext";
@@ -102,8 +103,10 @@ const PostArticle = () => {
             <Loading />
           ) : (
             <div>
+              <p className="mb-5"> * indicates required field</p>
+              <InputLabel htmlFor="select-topic">Select topic *</InputLabel>
               <Select
-                label="Select Topic"
+                id="select-topic"
                 value={selectedTopic}
                 onChange={(e) => setSelectedTopic(e.target.value)}
                 placeholder="Select a topic"
@@ -118,38 +121,49 @@ const PostArticle = () => {
                 })}
               </Select>
               {selectedTopic === "Create new topic..." ? (
-                <div className="flex justify-stretch w-[70%]">
-                  <TextField
-                    label="New topic name"
-                    value={newTopic}
-                    onChange={(e) => {
-                      setNewTopic(e.target.value);
-                    }}
-                    className="w-full"
-                  />
-                  <TextField
-                    label="Describe your new topic"
-                    value={newTopicDescription}
-                    margin="normal"
-                    onChange={(e) => {
-                      setNewTopicDescription(e.target.value);
-                    }}
-                    className="w-full"
-                  />
+                <div className="flex items-center justify-stretch w-[70%] mt-3">
+                  <div className="w-full mr-3">
+                    <InputLabel htmlFor="new-topic-name">
+                      New Topic Name *
+                    </InputLabel>
+                    <TextField
+                      id="new-topic-name"
+                      value={newTopic}
+                      placeholder="Marshmallows"
+                      onChange={(e) => {
+                        setNewTopic(e.target.value);
+                      }}
+                      className="w-full"
+                    />
+                  </div>
+                  <div className="w-full">
+                    <InputLabel htmlFor="topic-description">
+                      Describe your new topic *
+                    </InputLabel>
+                    <TextField
+                      id="new-topic-name"
+                      value={newTopicDescription}
+                      placeholder="Fluffy pillows for your mouth"
+                      onChange={(e) => {
+                        setNewTopicDescription(e.target.value);
+                      }}
+                      className="w-full"
+                    />
+                  </div>
                 </div>
               ) : null}
             </div>
           )}
 
           <TextField
-            label="Title"
+            label="Title *"
             value={articleTitle}
             onChange={(e) => setArticleTitle(e.target.value)}
             margin="normal"
             className="w-full"
           />
           <TextField
-            label="Body"
+            label="Body *"
             multiline
             rows={4}
             value={articleBody}

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -31,8 +31,20 @@ const PostArticle = () => {
         description: newTopicDescription,
       }).then(({ topic }) => {
         dispatch({ type: "added", data: topic });
+        setSelectedTopic(topic.slug);
       });
     }
+
+    const postRequestParams = {
+      title: articleTitle,
+      topic: selectedTopic,
+      author: user,
+      body: articleBody,
+      article_img_url: articleImg,
+    };
+    console.log(postRequestParams);
+
+    postRequest("/api/articles", postRequestParams).then(({ article }) => {});
   };
   const handleReset = (e) => {
     e.preventDefault();

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -26,6 +26,7 @@ const PostArticle = () => {
   const [articleBody, setArticleBody] = useState("");
   const [articleImg, setArticleImg] = useState("");
   const [articlePosted, setArticlePosted] = useState("No");
+  const [fieldsNotFilled, setFieldsNotFilled] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -37,6 +38,11 @@ const PostArticle = () => {
         dispatch({ type: "added", data: topic });
         setSelectedTopic(topic.slug);
       });
+    }
+
+    if (!articleTitle || !articleBody || !user || !selectedTopic) {
+      setFieldsNotFilled(true);
+      return;
     }
 
     const postRequestParams = {
@@ -90,6 +96,7 @@ const PostArticle = () => {
         >
           Reset
         </Button>
+        {fieldsNotFilled ? <p>Please fill in all required fields</p> : null}
         <form onSubmit={handleSubmit}>
           {awaitingTopics ? (
             <Loading />

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -1,18 +1,21 @@
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import { useState, useContext } from "react";
-import { TopicsContext } from "../contexts/TopicsContext";
-import { TopicsDispatchContext } from "../contexts/TopicsContext";
-import Loading from "./Loading";
 import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
 import PublishIcon from "@mui/icons-material/Publish";
+import { useState, useContext } from "react";
+import { Link } from "react-router-dom";
+import { TopicsContext } from "../contexts/TopicsContext";
+import { TopicsDispatchContext } from "../contexts/TopicsContext";
+import { UserContext } from "../contexts/UserContext";
 import { postRequest } from "../utils/api";
+import Loading from "./Loading";
 
 const PostArticle = () => {
   const { topics, awaitingTopics } = useContext(TopicsContext);
-  const dispatch  = useContext(TopicsDispatchContext);
+  const dispatch = useContext(TopicsDispatchContext);
+  const { user } = useContext(UserContext);
   const [selectedTopic, setSelectedTopic] = useState("");
   const [newTopic, setNewTopic] = useState("");
   const [newTopicDescription, setNewTopicDescription] = useState("");
@@ -28,7 +31,7 @@ const PostArticle = () => {
         description: newTopicDescription,
       }).then(({ topic }) => {
         dispatch({ type: "added", data: topic });
-      })
+      });
     }
   };
   const handleReset = (e) => {
@@ -42,6 +45,13 @@ const PostArticle = () => {
   return (
     <main>
       <h2 className=" font-mono text-[30px] ml-6">Post an article</h2>
+      <h3 className="ml-6">
+        {" "}
+        You are logged in as{" "}
+        <Link to="/account" className="text-red-700">
+          {user}
+        </Link>
+      </h3>
       <div className="m-auto w-[80%] flex flex-col">
         <Button
           variant="outlined"

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -1,5 +1,4 @@
 import TextField from "@mui/material/TextField";
-import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import { useState, useContext } from "react";
@@ -15,6 +14,7 @@ const PostArticle = () => {
   const [newTopic, setNewTopic] = useState("");
   const [articleTitle, setArticleTitle] = useState("");
   const [articleBody, setArticleBody] = useState("");
+  const [articleImg, setArticleImg] = useState("");
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -22,21 +22,26 @@ const PostArticle = () => {
   return (
     <main>
       <h2 className=" font-mono text-[30px] ml-6">Post an article</h2>
-      <div className="m-auto w-[80%]">
-        <Button variant="outlined" startIcon={<ReplayIcon />}>
+      <div className="m-auto w-[80%] flex flex-col">
+        <Button
+          variant="outlined"
+          startIcon={<ReplayIcon />}
+          className="place-self-end"
+        >
           Reset
         </Button>
         <form onSubmit={handleSubmit}>
           {awaitingTopics ? (
             <Loading />
           ) : (
-            <div>
+            <div className="flex justify-between">
               <Select
                 label="Select Topic"
                 value={selectedTopic}
                 onChange={(e) => setSelectedTopic(e.target.value)}
                 placeholder="Select a topic"
-                className="w-[50%]"
+                margin="normal"
+                className="w-[70%]"
               >
                 {[...topics, { slug: "Create new topic..." }].map((topic) => {
                   return (
@@ -50,6 +55,7 @@ const PostArticle = () => {
                 <TextField
                   label="New topic name"
                   value={newTopic}
+                  margin="normal"
                   onChange={(e) => {
                     setNewTopic(e.target.value);
                   }}
@@ -71,6 +77,13 @@ const PostArticle = () => {
             rows={4}
             value={articleBody}
             onChange={(e) => setArticleBody(e.target.value)}
+            margin="normal"
+            className="w-full"
+          />
+          <TextField
+            label="Article Image (URL)"
+            value={articleImg}
+            onChange={(e) => setArticleImg(e.target.value)}
             margin="normal"
             className="w-full"
           />

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -51,6 +51,11 @@ const PostArticle = () => {
       .then(({ article }) => {
         setArticlePosted("success");
         setTimeout(() => {
+          setSelectedTopic("");
+          setNewTopic("");
+          setArticleTitle("");
+          setArticleBody("");
+          setArticleImg("");
           navigate(`/articles/${article.article_id}`);
         }, 3000);
       })

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -19,6 +19,14 @@ const PostArticle = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
   };
+  const handleReset = (e) => {
+    e.preventDefault();
+    setSelectedTopic("");
+    setNewTopic("");
+    setArticleTitle("");
+    setArticleBody("");
+    setArticleImg("");
+  };
   return (
     <main>
       <h2 className=" font-mono text-[30px] ml-6">Post an article</h2>
@@ -26,6 +34,7 @@ const PostArticle = () => {
         <Button
           variant="outlined"
           startIcon={<ReplayIcon />}
+          onClick={handleReset}
           className="place-self-end"
         >
           Reset

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -3,6 +3,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import { useState, useContext } from "react";
 import { TopicsContext } from "../contexts/TopicsContext";
+import { TopicsDispatchContext } from "../contexts/TopicsContext";
 import Loading from "./Loading";
 import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
@@ -11,6 +12,7 @@ import { postRequest } from "../utils/api";
 
 const PostArticle = () => {
   const { topics, awaitingTopics } = useContext(TopicsContext);
+  const dispatch  = useContext(TopicsDispatchContext);
   const [selectedTopic, setSelectedTopic] = useState("");
   const [newTopic, setNewTopic] = useState("");
   const [newTopicDescription, setNewTopicDescription] = useState("");
@@ -24,6 +26,8 @@ const PostArticle = () => {
       postRequest("/api/topics/", {
         slug: newTopic,
         description: newTopicDescription,
+      }).then(({ topic }) => {
+        dispatch({ type: "added", data: topic });
       })
     }
   };

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -20,6 +20,12 @@ const PostArticle = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (newTopic) {
+      postRequest("/api/topics/", {
+        slug: newTopic,
+        description: newTopicDescription,
+      })
+    }
   };
   const handleReset = (e) => {
     e.preventDefault();
@@ -51,7 +57,6 @@ const PostArticle = () => {
                 value={selectedTopic}
                 onChange={(e) => setSelectedTopic(e.target.value)}
                 placeholder="Select a topic"
-                margin="normal"
                 className="w-[70%]"
               >
                 {[...topics, { slug: "Create new topic..." }].map((topic) => {
@@ -67,7 +72,6 @@ const PostArticle = () => {
                   <TextField
                     label="New topic name"
                     value={newTopic}
-                    margin="normal"
                     onChange={(e) => {
                       setNewTopic(e.target.value);
                     }}

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -78,6 +78,8 @@ const PostArticle = () => {
     setArticleBody("");
     setArticleImg("");
   };
+
+  const formInputStyleProps = { sx: { borderRadius: "30px" } };
   return (
     <main>
       <h2 className=" font-mono text-[30px] ml-6">Post an article</h2>
@@ -94,16 +96,25 @@ const PostArticle = () => {
           startIcon={<ReplayIcon />}
           onClick={handleReset}
           className="place-self-end"
+          sx={{
+            borderRadius: "30px",
+            color: "darkred",
+            border: "1px solid darkred",
+          }}
         >
           Reset
         </Button>
-        {fieldsNotFilled ? <p>Please fill in all required fields</p> : null}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col">
           {awaitingTopics ? (
             <Loading />
           ) : (
             <div>
-              <p className="mb-5"> * indicates required field</p>
+              <p> * indicates required field</p>
+              {fieldsNotFilled ? (
+                <p className=" text-red-700 mb-5">
+                  Please fill in all required fields
+                </p>
+              ) : null}
               <InputLabel htmlFor="select-topic">Select topic *</InputLabel>
               <Select
                 id="select-topic"
@@ -111,6 +122,7 @@ const PostArticle = () => {
                 onChange={(e) => setSelectedTopic(e.target.value)}
                 placeholder="Select a topic"
                 className="w-[70%]"
+                sx={{ borderRadius: "30px" }}
               >
                 {[...topics, { slug: "Create new topic..." }].map((topic) => {
                   return (
@@ -134,6 +146,7 @@ const PostArticle = () => {
                         setNewTopic(e.target.value);
                       }}
                       className="w-full"
+                      InputProps={formInputStyleProps}
                     />
                   </div>
                   <div className="w-full">
@@ -148,6 +161,7 @@ const PostArticle = () => {
                         setNewTopicDescription(e.target.value);
                       }}
                       className="w-full"
+                      InputProps={formInputStyleProps}
                     />
                   </div>
                 </div>
@@ -161,6 +175,7 @@ const PostArticle = () => {
             onChange={(e) => setArticleTitle(e.target.value)}
             margin="normal"
             className="w-full"
+            InputProps={formInputStyleProps}
           />
           <TextField
             label="Body *"
@@ -170,6 +185,7 @@ const PostArticle = () => {
             onChange={(e) => setArticleBody(e.target.value)}
             margin="normal"
             className="w-full"
+            InputProps={formInputStyleProps}
           />
           <TextField
             label="Article Image (URL)"
@@ -177,8 +193,19 @@ const PostArticle = () => {
             onChange={(e) => setArticleImg(e.target.value)}
             margin="normal"
             className="w-full"
+            InputProps={formInputStyleProps}
           />
-          <Button type="submit" variant="outlined" startIcon={<PublishIcon />}>
+          <Button
+            type="submit"
+            variant="outlined"
+            startIcon={<PublishIcon />}
+            sx={{
+              borderRadius: "30px",
+              color: "darkred",
+              border: "1px solid darkred",
+            }}
+            className="place-self-center"
+          >
             Post Article
           </Button>
         </form>

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -5,7 +5,7 @@ import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
 import PublishIcon from "@mui/icons-material/Publish";
 import { useState, useContext } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { TopicsContext } from "../contexts/TopicsContext";
 import { TopicsDispatchContext } from "../contexts/TopicsContext";
 import { UserContext } from "../contexts/UserContext";
@@ -16,12 +16,16 @@ const PostArticle = () => {
   const { topics, awaitingTopics } = useContext(TopicsContext);
   const dispatch = useContext(TopicsDispatchContext);
   const { user } = useContext(UserContext);
+
+  const navigate = useNavigate();
+
   const [selectedTopic, setSelectedTopic] = useState("");
   const [newTopic, setNewTopic] = useState("");
   const [newTopicDescription, setNewTopicDescription] = useState("");
   const [articleTitle, setArticleTitle] = useState("");
   const [articleBody, setArticleBody] = useState("");
   const [articleImg, setArticleImg] = useState("");
+  const [articlePosted, setArticlePosted] = useState("No");
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -42,9 +46,17 @@ const PostArticle = () => {
       body: articleBody,
       article_img_url: articleImg,
     };
-    console.log(postRequestParams);
 
-    postRequest("/api/articles", postRequestParams).then(({ article }) => {});
+    postRequest("/api/articles", postRequestParams)
+      .then(({ article }) => {
+        setArticlePosted("success");
+        setTimeout(() => {
+          navigate(`/articles/${article.article_id}`);
+        }, 3000);
+      })
+      .catch(() => {
+        setArticlePosted("error");
+      });
   };
   const handleReset = (e) => {
     e.preventDefault();
@@ -144,6 +156,16 @@ const PostArticle = () => {
             Post Article
           </Button>
         </form>
+        {articlePosted === "success" ? (
+          <p className="text-green-700">
+            Article Posted! Navigating to new article...
+          </p>
+        ) : null}
+        {articlePosted === "error" ? (
+          <p className="text-red-700">
+            Error posting article. Please try again later.
+          </p>
+        ) : null}
       </div>
     </main>
   );

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -1,2 +1,85 @@
-const PostArticle = () => {};
+import TextField from "@mui/material/TextField";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import { useState, useContext } from "react";
+import { TopicsContext } from "../contexts/TopicsContext";
+import Loading from "./Loading";
+import Button from "@mui/material/Button";
+import ReplayIcon from "@mui/icons-material/Replay";
+import PublishIcon from "@mui/icons-material/Publish";
+
+const PostArticle = () => {
+  const { topics, awaitingTopics } = useContext(TopicsContext);
+  const [selectedTopic, setSelectedTopic] = useState("");
+  const [newTopic, setNewTopic] = useState("");
+  const [articleTitle, setArticleTitle] = useState("");
+  const [articleBody, setArticleBody] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+  return (
+    <main>
+      <h2 className=" font-mono text-[30px] ml-6">Post an article</h2>
+      <div className="m-auto w-[80%]">
+        <Button variant="outlined" startIcon={<ReplayIcon />}>
+          Reset
+        </Button>
+        <form onSubmit={handleSubmit}>
+          {awaitingTopics ? (
+            <Loading />
+          ) : (
+            <div>
+              <Select
+                label="Select Topic"
+                value={selectedTopic}
+                onChange={(e) => setSelectedTopic(e.target.value)}
+                placeholder="Select a topic"
+                className="w-[50%]"
+              >
+                {[...topics, { slug: "Create new topic..." }].map((topic) => {
+                  return (
+                    <MenuItem key={topic.slug} value={topic.slug}>
+                      {topic.slug}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+              {selectedTopic === "Create new topic..." ? (
+                <TextField
+                  label="New topic name"
+                  value={newTopic}
+                  onChange={(e) => {
+                    setNewTopic(e.target.value);
+                  }}
+                />
+              ) : null}
+            </div>
+          )}
+
+          <TextField
+            label="Title"
+            value={articleTitle}
+            onChange={(e) => setArticleTitle(e.target.value)}
+            margin="normal"
+            className="w-full"
+          />
+          <TextField
+            label="Body"
+            multiline
+            rows={4}
+            value={articleBody}
+            onChange={(e) => setArticleBody(e.target.value)}
+            margin="normal"
+            className="w-full"
+          />
+          <Button type="submit" variant="outlined" startIcon={<PublishIcon />}>
+            Post Article
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+};
 export default PostArticle;

--- a/src/components/PostArticle.jsx
+++ b/src/components/PostArticle.jsx
@@ -7,11 +7,13 @@ import Loading from "./Loading";
 import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
 import PublishIcon from "@mui/icons-material/Publish";
+import { postRequest } from "../utils/api";
 
 const PostArticle = () => {
   const { topics, awaitingTopics } = useContext(TopicsContext);
   const [selectedTopic, setSelectedTopic] = useState("");
   const [newTopic, setNewTopic] = useState("");
+  const [newTopicDescription, setNewTopicDescription] = useState("");
   const [articleTitle, setArticleTitle] = useState("");
   const [articleBody, setArticleBody] = useState("");
   const [articleImg, setArticleImg] = useState("");
@@ -43,7 +45,7 @@ const PostArticle = () => {
           {awaitingTopics ? (
             <Loading />
           ) : (
-            <div className="flex justify-between">
+            <div>
               <Select
                 label="Select Topic"
                 value={selectedTopic}
@@ -61,14 +63,26 @@ const PostArticle = () => {
                 })}
               </Select>
               {selectedTopic === "Create new topic..." ? (
-                <TextField
-                  label="New topic name"
-                  value={newTopic}
-                  margin="normal"
-                  onChange={(e) => {
-                    setNewTopic(e.target.value);
-                  }}
-                />
+                <div className="flex justify-stretch w-[70%]">
+                  <TextField
+                    label="New topic name"
+                    value={newTopic}
+                    margin="normal"
+                    onChange={(e) => {
+                      setNewTopic(e.target.value);
+                    }}
+                    className="w-full"
+                  />
+                  <TextField
+                    label="Describe your new topic"
+                    value={newTopicDescription}
+                    margin="normal"
+                    onChange={(e) => {
+                      setNewTopicDescription(e.target.value);
+                    }}
+                    className="w-full"
+                  />
+                </div>
               ) : null}
             </div>
           )}

--- a/src/contexts/TopicsContext.jsx
+++ b/src/contexts/TopicsContext.jsx
@@ -1,18 +1,20 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useEffect, useState, useReducer } from "react";
 import { getRequest } from "../utils/api";
+import topicsReducer from "../utils/reducers";
 export const TopicsContext = createContext();
+export const TopicsDispatchContext = createContext();
 
 export const TopicsProvider = ({ children }) => {
-  const [topics, setTopics] = useState([]);
   const [awaitingTopics, setAwaitingTopics] = useState(true);
-  const [error, setError] = useState(null);
+  const [topics, dispatch] = useReducer(topicsReducer, []);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
         const { topics } = await getRequest("/api/topics/");
-        setTopics(topics);
+        dispatch({ type: "initialDataFetched", data: topics });
       } catch (err) {
-        setError(err);
+        console.log(err);
       } finally {
         setAwaitingTopics(false);
       }
@@ -22,8 +24,10 @@ export const TopicsProvider = ({ children }) => {
   }, []);
 
   return (
-    <TopicsContext.Provider value={{ topics, setTopics, awaitingTopics }}>
-      {children}
+    <TopicsContext.Provider value={{ topics, awaitingTopics }}>
+      <TopicsDispatchContext.Provider value={dispatch}>
+        {children}
+      </TopicsDispatchContext.Provider>
     </TopicsContext.Provider>
   );
 };

--- a/src/contexts/TopicsContext.jsx
+++ b/src/contexts/TopicsContext.jsx
@@ -1,0 +1,29 @@
+import { createContext, useEffect, useState } from "react";
+import { getRequest } from "../utils/api";
+export const TopicsContext = createContext();
+
+export const TopicsProvider = ({ children }) => {
+  const [topics, setTopics] = useState([]);
+  const [awaitingTopics, setAwaitingTopics] = useState(true);
+  const [error, setError] = useState(null);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const { topics } = await getRequest("/api/topics/");
+        setTopics(topics);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setAwaitingTopics(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <TopicsContext.Provider value={{ topics, awaitingTopics }}>
+      {children}
+    </TopicsContext.Provider>
+  );
+};

--- a/src/contexts/TopicsContext.jsx
+++ b/src/contexts/TopicsContext.jsx
@@ -22,7 +22,7 @@ export const TopicsProvider = ({ children }) => {
   }, []);
 
   return (
-    <TopicsContext.Provider value={{ topics, awaitingTopics }}>
+    <TopicsContext.Provider value={{ topics, setTopics, awaitingTopics }}>
       {children}
     </TopicsContext.Provider>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,9 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./output.css";
 import { UserProvider } from "./contexts/UserContext.jsx";
+import { TopicsProvider } from "./contexts/TopicsContext.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <UserProvider>
-    <App />
+    <TopicsProvider>
+      <App />
+    </TopicsProvider>
   </UserProvider>
 );

--- a/src/output.css
+++ b/src/output.css
@@ -558,6 +558,14 @@ video {
   position: fixed;
 }
 
+.absolute {
+  position: absolute;
+}
+
+.right-0 {
+  right: 0px;
+}
+
 .col-span-2 {
   grid-column: span 2 / span 2;
 }
@@ -576,6 +584,14 @@ video {
 
 .m-auto {
   margin: auto;
+}
+
+.m-3 {
+  margin: 0.75rem;
+}
+
+.m-4 {
+  margin: 1rem;
 }
 
 .mb-10 {
@@ -634,6 +650,14 @@ video {
   margin-left: 0.25rem;
 }
 
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
 .flex {
   display: flex;
 }
@@ -682,6 +706,18 @@ video {
   width: 100%;
 }
 
+.w-\[80\%\] {
+  width: 80%;
+}
+
+.w-\[50\%\] {
+  width: 50%;
+}
+
+.w-\[70\%\] {
+  width: 70%;
+}
+
 .min-w-\[160px\] {
   min-width: 160px;
 }
@@ -692,6 +728,14 @@ video {
 
 .max-w-\[180px\] {
   max-width: 180px;
+}
+
+.max-w-\[50\%\] {
+  max-width: 50%;
+}
+
+.grow {
+  flex-grow: 1;
 }
 
 .resize {
@@ -714,6 +758,10 @@ video {
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .grid-rows-2 {
   grid-template-rows: repeat(2, minmax(0, 1fr));
 }
@@ -724,6 +772,10 @@ video {
 
 .flex-col {
   flex-direction: column;
+}
+
+.place-items-end {
+  place-items: end;
 }
 
 .place-items-center {
@@ -738,6 +790,22 @@ video {
   justify-content: center;
 }
 
+.justify-between {
+  justify-content: space-between;
+}
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.justify-evenly {
+  justify-content: space-evenly;
+}
+
+.justify-stretch {
+  justify-content: stretch;
+}
+
 .gap-x-2 {
   -moz-column-gap: 0.5rem;
        column-gap: 0.5rem;
@@ -747,6 +815,18 @@ video {
   --tw-space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.place-self-end {
+  place-self: end;
+}
+
+.place-self-center {
+  place-self: center;
+}
+
+.text-nowrap {
+  text-wrap: nowrap;
 }
 
 .rounded {
@@ -841,6 +921,10 @@ video {
   text-align: center;
 }
 
+.text-right {
+  text-align: right;
+}
+
 .font-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
@@ -896,6 +980,11 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.text-green-700 {
+  --tw-text-opacity: 1;
+  color: rgb(21 128 61 / var(--tw-text-opacity));
 }
 
 .filter {

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -1,0 +1,15 @@
+const topicsReducer = (topics, action) => {
+  switch (action.type) {
+    case "initialDataFetched": {
+      return action.data;
+    }
+    case "added": {
+      return [...topics, action.data];
+    }
+    default: {
+      throw Error("Unknown action: " + action.type);
+    }
+  }
+};
+
+export default topicsReducer;


### PR DESCRIPTION
Added functionality for a logged in user to post an article
- A logged in user can navigate to /articles/post from the NavBar in the header.
- Utilised MaterialUI input components to create the form on the post articles page. This was styled with a mix of Tailwindcss and passing down css on the sx props.
- Users can create a new topic to add articles to from the form. In order to do this I had to change how the topics were stored, from state to a context provider. I created a reducer function using React's useReduce that is invoked when a new topic is created in the PostArticle component in order to update the topics stored in context.
