### PR TITLE
21 articles pagination

### DIFF
--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -9,6 +9,7 @@ import ArticlesSideBar from "./ArticlesSideBar";
 import ErrorComponent from "./ErrorComponent";
 import ArticlesListOptions from "./ArticlesListOptions";
 import { TopicsContext } from "../contexts/TopicsContext";
+import Pagination from "@mui/material/Pagination";
 
 const Articles = ({
   listArticles,
@@ -26,6 +27,7 @@ const Articles = ({
   const [error, setError] = useState(null);
   const [page, setPage] = useState(1);
   const [totalArticleCount, setTotalArticleCount] = useState(0);
+
   useEffect(() => {
     let getRequestURL = "/api/articles?";
     getRequestURL += currentTopic ? `topic=${currentTopic}` : "";
@@ -36,13 +38,13 @@ const Articles = ({
     getRequestURL += order && sortBy ? `&order=${order}` : "";
     getRequestURL += `&p=${page}`;
 
-    getRequest(getRequestURL)
-      .then((body) => {
-        const { articles, total_count } = body;
-        setTotalArticleCount(total_count);
-        setlistArticles(articles);
-        setIsLoading(false);
-      })
+    console.log(page);
+    getRequest(getRequestURL).then((body) => {
+      const { articles, total_count } = body;
+      setTotalArticleCount(total_count);
+      setlistArticles(articles);
+      setIsLoading(false);
+    });
   }, [sortBy, order, page]);
 
   useEffect(() => {
@@ -53,25 +55,6 @@ const Articles = ({
       setCurrentTopicDescription(currentTopicApi[0].description);
     }
   }, [currentTopic]);
-
-  const ArticlesNavButton = ({ icon, pageIncrement }) => {
-    console.log(page);
-
-    const handleClick = () => {
-      if (
-        (pageIncrement === -1 && page === 1) |
-        (pageIncrement === 1 && listArticles.length < 10)
-      )
-        return;
-      else {
-        setPage((currPage) => {
-          return currPage + pageIncrement;
-        });
-      }
-    };
-
-    return <button onClick={handleClick}>{icon}</button>;
-  };
 
   return (
     <div className="flex">
@@ -121,8 +104,13 @@ const Articles = ({
             })}
           </div>
         )}
-        <ArticlesNavButton icon={<NavigateBeforeIcon />} pageIncrement={-1} />
-        <ArticlesNavButton icon={<NavigateNextIcon />} pageIncrement={1} />
+        <Pagination
+          count={Math.ceil(totalArticleCount / 10)}
+          onChange={(e, page) => {
+            e.preventDefault();
+            setPage(page);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,8 +1,6 @@
 import { getRequest } from "../utils/api";
 import { useContext, useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
-import NavigateNextIcon from "@mui/icons-material/NavigateNext";
-import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
 import ArticleCard from "./ArticleCard";
 import Loading from "./Loading";
 import ArticlesSideBar from "./ArticlesSideBar";
@@ -38,7 +36,6 @@ const Articles = ({
     getRequestURL += order && sortBy ? `&order=${order}` : "";
     getRequestURL += `&p=${page}`;
 
-    console.log(page);
     getRequest(getRequestURL).then((body) => {
       const { articles, total_count } = body;
       setTotalArticleCount(total_count);
@@ -99,18 +96,21 @@ const Articles = ({
                   article={article}
                   setArticle={setlistArticles}
                   key={article.article_id}
+                  className=" w-full"
                 />
               );
             })}
+            <div className="flex justify-center pb-10 pt-3 w-full">
+              <Pagination
+                count={Math.ceil(totalArticleCount / 10)}
+                onChange={(e, page) => {
+                  e.preventDefault();
+                  setPage(page);
+                }}
+              />
+            </div>
           </div>
         )}
-        <Pagination
-          count={Math.ceil(totalArticleCount / 10)}
-          onChange={(e, page) => {
-            e.preventDefault();
-            setPage(page);
-          }}
-        />
       </div>
     </div>
   );

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,6 +1,8 @@
 import { getRequest } from "../utils/api";
 import { useContext, useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
 import ArticleCard from "./ArticleCard";
 import Loading from "./Loading";
 import ArticlesSideBar from "./ArticlesSideBar";
@@ -50,6 +52,25 @@ const Articles = ({
     }
   }, [currentTopic]);
 
+  const ArticlesNavButton = ({ icon, pageIncrement }) => {
+    console.log(page);
+
+    const handleClick = () => {
+      if (
+        (pageIncrement === -1 && page === 1) |
+        (pageIncrement === 1 && listArticles.length < 10)
+      )
+        return;
+      else {
+        setPage((currPage) => {
+          return currPage + pageIncrement;
+        });
+      }
+    };
+
+    return <button onClick={handleClick}>{icon}</button>;
+  };
+
   return (
     <div className="flex">
       <ArticlesSideBar currentTopic={currentTopic} />
@@ -98,6 +119,8 @@ const Articles = ({
             })}
           </div>
         )}
+        <ArticlesNavButton icon={<NavigateBeforeIcon />} pageIncrement={-1} />
+        <ArticlesNavButton icon={<NavigateNextIcon />} pageIncrement={1} />
       </div>
     </div>
   );

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -25,6 +25,7 @@ const Articles = ({
   const [order, setOrder] = useState(searchParams.get("order"));
   const [error, setError] = useState(null);
   const [page, setPage] = useState(1);
+  const [totalArticleCount, setTotalArticleCount] = useState(0);
   useEffect(() => {
     let getRequestURL = "/api/articles?";
     getRequestURL += currentTopic ? `topic=${currentTopic}` : "";
@@ -36,12 +37,13 @@ const Articles = ({
     getRequestURL += `&p=${page}`;
 
     getRequest(getRequestURL)
-      .then(({ articles }) => {
+      .then((body) => {
+        const { articles, total_count } = body;
+        setTotalArticleCount(total_count);
         setlistArticles(articles);
         setIsLoading(false);
       })
-      .catch((err) => setError(err));
-  }, [sortBy, order]);
+  }, [sortBy, order, page]);
 
   useEffect(() => {
     if (currentTopic && !awaitingTopics) {

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -22,6 +22,7 @@ const Articles = ({
   const [sortBy, setSortBy] = useState(searchParams.get("sort_by"));
   const [order, setOrder] = useState(searchParams.get("order"));
   const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
   useEffect(() => {
     let getRequestURL = "/api/articles?";
     getRequestURL += currentTopic ? `topic=${currentTopic}` : "";
@@ -30,6 +31,7 @@ const Articles = ({
 
     getRequestURL += sortBy ? `sort_by=${sortBy}` : "";
     getRequestURL += order && sortBy ? `&order=${order}` : "";
+    getRequestURL += `&p=${page}`;
 
     getRequest(getRequestURL)
       .then(({ articles }) => {

--- a/src/output.css
+++ b/src/output.css
@@ -897,6 +897,10 @@ video {
   place-self: center;
 }
 
+.justify-self-center {
+  justify-self: center;
+}
+
 .text-nowrap {
   text-wrap: nowrap;
 }
@@ -997,6 +1001,11 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.bg-red-700 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+}
+
 .p-1 {
   padding: 0.25rem;
 }
@@ -1024,6 +1033,18 @@ video {
 
 .pl-1 {
   padding-left: 0.25rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pb-10 {
+  padding-bottom: 2.5rem;
+}
+
+.pt-3 {
+  padding-top: 0.75rem;
 }
 
 .text-center {


### PR DESCRIPTION
Utilised the page and limit queries on the API articles endpoint to implement pagination of articles. I used a MaterialUI component for the buttons an handled the page change by updated the page (stored in state), which as a useEffect dependency fetched the next page of articles from the API.